### PR TITLE
修复iOS15 导航栏动画异常

### DIFF
--- a/KMNavigationBarTransition/UIViewController+KMNavigationBarTransition.m
+++ b/KMNavigationBarTransition/UIViewController+KMNavigationBarTransition.m
@@ -150,6 +150,11 @@
     }
     [self.km_transitionNavigationBar removeFromSuperview];
     self.km_transitionNavigationBar = bar;
+    if (@available(iOS 15, *)) {
+        if (bar.scrollEdgeAppearance == nil) {
+            self.km_transitionNavigationBar = nil;
+        }
+    }
     [self km_resizeTransitionNavigationBarFrame];
     if (!self.navigationController.navigationBarHidden && !self.navigationController.navigationBar.hidden) {
         [self.view addSubview:self.km_transitionNavigationBar];


### PR DESCRIPTION
当前页面导航栏透明，下一页面不透明。来回切换动画替换假的导航栏颜色异常处理